### PR TITLE
fix entry_iterator include for unix

### DIFF
--- a/src/entry_iterator.cpp
+++ b/src/entry_iterator.cpp
@@ -35,6 +35,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <errno.h>
+#include <stdexcept>
 #elif defined(_WIN32)
 #include <Windows.h>
 #else


### PR DESCRIPTION
When compiling on Linux, I got a compiler error:

```
.../pathie/src/entry_iterator.cpp: In member function ‘Pathie::entry_iterator& Pathie::entry_iterator::operator++(int)’:
.../pathie/src/entry_iterator.cpp:172:12: error: ‘range_error’ is not a member of ‘std’
      throw(std::range_error("Tried to advance a finished entry_iterator!"));
```

Therefor I added the stdexcept header and it compiles successfully.