### PR TITLE
Add experimental mac support and fix compilation if UTF8 support is assumed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,10 +117,16 @@ file(GLOB_RECURSE test_sources
 
 # Libraries
 add_library(pathie STATIC ${pathie_sources})
+if(APPLE)
+  target_link_libraries(pathie iconv)
+endif()
 
 if (CMAKE_BUILD_SHARED_LIBS)
   add_library(pathie-dynamic SHARED ${pathie_sources})
   set_target_properties(pathie-dynamic PROPERTIES OUTPUT_NAME pathie)
+  if(APPLE)
+    target_link_libraries(pathie-dynamic iconv)
+  endif()
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,9 @@ if (WIN32)
   add_definitions("-D_WIN32_WINNT=0x0600") # Vista
   add_definitions("-D_WIN32_IE=0x0800") # IE 8.0+
   add_definitions("-DWINVER=0x0600") # Vista
+elseif(APPLE)
+  add_definitions("-D_DARWIN_C_SOURCE")
+  add_definitions("-D_PATHIE_UNIX=1")
 elseif(UNIX)
   add_definitions("-D_PATHIE_UNIX=1")
   add_definitions("-D_POSIX_C_SOURCE=200112L")

--- a/src/entry_iterator.cpp
+++ b/src/entry_iterator.cpp
@@ -31,7 +31,7 @@
 #include "../include/path.hpp"
 #include "../include/errors.hpp"
 
-#if defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
 #include <sys/types.h>
 #include <dirent.h>
 #include <errno.h>

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -79,6 +79,10 @@
 #include <sys/sysctl.h>
 #endif
 
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
 using namespace Pathie;
 using namespace std;
 
@@ -913,6 +917,16 @@ Path Path::exe()
     throw(Pathie::ErrnoError(errno));
 
   return Path(filename_to_utf8(std::string(buf, size)));
+#elif defined(__APPLE__)
+  char buf[PATH_MAX];
+  uint32_t size = sizeof(buf);
+
+  if (_NSGetExecutablePath(buf, &size) == 0)
+    // Might contain symlinks or extra slashes. Shouldn't be an issue though
+    // https://stackoverflow.com/questions/799679/programmatically-retrieving-the-absolute-path-of-an-os-x-command-line-app/1024933#1024933
+    return Path(filename_to_utf8(std::string(buf, size)));
+  else
+    throw(Pathie::ErrnoError(errno));
 #elif defined(BSD)
   // BSD does not have /proc mounted by default. However, using raw syscalls,
   // we can figure out what would have been in /proc/curproc/file. See

--- a/src/pathie.cpp
+++ b/src/pathie.cpp
@@ -143,7 +143,7 @@ std::string Pathie::convert_encodings(const char* from_encoding, const char* to_
     errno  = 0;
     errsav = 0;
 
-#ifdef BSD
+#if defined(BSD) && ! defined(__APPLE__) //Since MacOS evolved from BSD, it is captured here
     // What the heck. FreeBSD violates POSIX.1-2008: it declares iconv()
     // differently than mandated by POSIX: http://pubs.opengroup.org/onlinepubs/9699919799/functions/iconv.html
     // (it declares a `const' where it must not be).
@@ -181,11 +181,11 @@ std::string Pathie::convert_encodings(const char* from_encoding, const char* to_
 std::string Pathie::utf8_to_filename(const std::string& utf8)
 {
   bool fs_encoding_is_utf8 = false;
+  char* fsencoding = NULL;
 
 #if defined(__APPLE__) || defined(PATHIE_ASSUME_UTF8_ON_UNIX)
   fs_encoding_is_utf8 = true;
 #else
-  char* fsencoding = NULL;
   fsencoding = nl_langinfo(CODESET);
   fs_encoding_is_utf8 = (strcmp(fsencoding, "UTF-8") == 0);
 #endif
@@ -206,11 +206,11 @@ std::string Pathie::utf8_to_filename(const std::string& utf8)
 std::string Pathie::filename_to_utf8(const std::string& native_filename)
 {
   bool fs_encoding_is_utf8 = false;
+  char* fsencoding = NULL;
 
 #if defined(__APPLE__) || defined(PATHIE_ASSUME_UTF8_ON_UNIX)
   fs_encoding_is_utf8 = true;
 #else
-  char* fsencoding = NULL;
   fsencoding = nl_langinfo(CODESET);
   fs_encoding_is_utf8 = (strcmp(fsencoding, "UTF-8") == 0);
 #endif


### PR DESCRIPTION
This should add experimental mac support and perform the additional fixes necessary in #10

A few changes in the CMakeLIsts.txt are necessary, to change the C style, as well as add an explicit linking to iconv.

On the code side, the most significant change is in the `path Path::exe()` function, which requires an entirely different codepath on mac.

I have not run the tests, as they seem to be outdated/broken.