### PR TITLE
Fix compiler warnings.

### DIFF
--- a/include/path.hpp
+++ b/include/path.hpp
@@ -39,15 +39,6 @@
 
 namespace Pathie {
 
-  // Forward-declare, defined in pathie.cpp.
-#if defined(_WIN32)
-  std::string utf16_to_utf8(std::wstring);
-  std::wstring utf8_to_utf16(std::string);
-#elif defined(_PATHIE_UNIX)
-  std::string utf8_to_filename(const std::string& utf8);
-  std::string filename_to_utf8(const std::string& native_filename);
-#endif
-
   /**
    * \brief Main class, describing paths.
    *

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -3176,14 +3176,14 @@ std::vector<Path> Path::glob(const std::string& pattern, int flags /* = 0 */)
     return std::vector<Path>(); // Empty vector
   }
   else if (result == 0) {
-    std::vector<Path> result;
+    std::vector<Path> paths;
 
     for(size_t i=0; i < globinfo.gl_pathc; i++) {
-      result.push_back(Path(filename_to_utf8(globinfo.gl_pathv[i])));
+      paths.push_back(Path(filename_to_utf8(globinfo.gl_pathv[i])));
     }
 
     globfree(&globinfo);
-    return result;
+    return paths;
   }
   else {
     throw(GlobError(result));


### PR DESCRIPTION
Fix warnings raised by -Wredundant-decls and -Wshadow.

This can improve quality of life for users who include pathie as a git submodule in a large project with many warning options enabled.

Output from sample project before changes:
```
[ 12%] Building CXX object pathie-cpp/CMakeFiles/pathie.dir/src/errors.cpp.o
[ 25%] Building CXX object pathie-cpp/CMakeFiles/pathie.dir/src/entry_iterator.cpp.o
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/entry_iterator.cpp:31:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:47:15: warning: redundant redeclaration of ‘std::__cxx11::string Pathie::utf8_to_filename(const string&)’ in same scope [-Wredundant-decls]
   std::string utf8_to_filename(const std::string& utf8);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:37,
                 from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/entry_iterator.cpp:31:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/pathie.hpp:60:15: note: previous declaration of ‘std::__cxx11::string Pathie::utf8_to_filename(const string&)’
   std::string utf8_to_filename(const std::string& utf8);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/entry_iterator.cpp:31:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:48:15: warning: redundant redeclaration of ‘std::__cxx11::string Pathie::filename_to_utf8(const string&)’ in same scope [-Wredundant-decls]
   std::string filename_to_utf8(const std::string& native_filename);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:37,
                 from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/entry_iterator.cpp:31:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/pathie.hpp:61:15: note: previous declaration of ‘std::__cxx11::string Pathie::filename_to_utf8(const string&)’
   std::string filename_to_utf8(const std::string& native_filename);
               ^~~~~~~~~~~~~~~~
[ 37%] Building CXX object pathie-cpp/CMakeFiles/pathie.dir/src/path.cpp.o
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/path.cpp:30:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:47:15: warning: redundant redeclaration of ‘std::__cxx11::string Pathie::utf8_to_filename(const string&)’ in same scope [-Wredundant-decls]
   std::string utf8_to_filename(const std::string& utf8);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:37,
                 from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/path.cpp:30:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/pathie.hpp:60:15: note: previous declaration of ‘std::__cxx11::string Pathie::utf8_to_filename(const string&)’
   std::string utf8_to_filename(const std::string& utf8);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/path.cpp:30:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:48:15: warning: redundant redeclaration of ‘std::__cxx11::string Pathie::filename_to_utf8(const string&)’ in same scope [-Wredundant-decls]
   std::string filename_to_utf8(const std::string& native_filename);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:37,
                 from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/path.cpp:30:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/pathie.hpp:61:15: note: previous declaration of ‘std::__cxx11::string Pathie::filename_to_utf8(const string&)’
   std::string filename_to_utf8(const std::string& native_filename);
               ^~~~~~~~~~~~~~~~
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/path.cpp: In static member function ‘static std::vector<Pathie::Path> Pathie::Path::glob(const string&, int)’:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/path.cpp:3179:23: warning: declaration of ‘result’ shadows a previous local [-Wshadow]
     std::vector<Path> result;
                       ^~~~~~
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/path.cpp:3173:7: note: shadowed declaration is here
   int result = ::glob(nstr.c_str(), flags, NULL, &globinfo);
       ^~~~~~
[ 50%] Building CXX object pathie-cpp/CMakeFiles/pathie.dir/src/temp.cpp.o
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/temp.hpp:3,
                 from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/temp.cpp:1:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:47:15: warning: redundant redeclaration of ‘std::__cxx11::string Pathie::utf8_to_filename(const string&)’ in same scope [-Wredundant-decls]
   std::string utf8_to_filename(const std::string& utf8);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:37,
                 from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/temp.hpp:3,
                 from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/temp.cpp:1:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/pathie.hpp:60:15: note: previous declaration of ‘std::__cxx11::string Pathie::utf8_to_filename(const string&)’
   std::string utf8_to_filename(const std::string& utf8);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/temp.hpp:3,
                 from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/temp.cpp:1:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:48:15: warning: redundant redeclaration of ‘std::__cxx11::string Pathie::filename_to_utf8(const string&)’ in same scope [-Wredundant-decls]
   std::string filename_to_utf8(const std::string& native_filename);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/path.hpp:37,
                 from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/temp.hpp:3,
                 from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/temp.cpp:1:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/src/../include/pathie.hpp:61:15: note: previous declaration of ‘std::__cxx11::string Pathie::filename_to_utf8(const string&)’
   std::string filename_to_utf8(const std::string& native_filename);
               ^~~~~~~~~~~~~~~~
[ 62%] Building CXX object pathie-cpp/CMakeFiles/pathie.dir/src/pathie.cpp.o
[ 75%] Linking CXX static library libpathie.a
[ 75%] Built target pathie
[ 87%] Building CXX object CMakeFiles/list_app_dirs.dir/src/main.cpp.o
In file included from /home/user4/PycharmProjects/list_app_dirs/src/main.cpp:3:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/include/path.hpp:47:15: warning: redundant redeclaration of ‘std::__cxx11::string Pathie::utf8_to_filename(const string&)’ in same scope [-Wredundant-decls]
   std::string utf8_to_filename(const std::string& utf8);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/include/path.hpp:37,
                 from /home/user4/PycharmProjects/list_app_dirs/src/main.cpp:3:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/include/pathie.hpp:60:15: note: previous declaration of ‘std::__cxx11::string Pathie::utf8_to_filename(const string&)’
   std::string utf8_to_filename(const std::string& utf8);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/src/main.cpp:3:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/include/path.hpp:48:15: warning: redundant redeclaration of ‘std::__cxx11::string Pathie::filename_to_utf8(const string&)’ in same scope [-Wredundant-decls]
   std::string filename_to_utf8(const std::string& native_filename);
               ^~~~~~~~~~~~~~~~
In file included from /home/user4/PycharmProjects/list_app_dirs/pathie-cpp/include/path.hpp:37,
                 from /home/user4/PycharmProjects/list_app_dirs/src/main.cpp:3:
/home/user4/PycharmProjects/list_app_dirs/pathie-cpp/include/pathie.hpp:61:15: note: previous declaration of ‘std::__cxx11::string Pathie::filename_to_utf8(const string&)’
   std::string filename_to_utf8(const std::string& native_filename);
               ^~~~~~~~~~~~~~~~
[100%] Linking CXX executable list_app_dirs
[100%] Built target list_app_dirs
```

Output after changes:
```
[ 12%] Building CXX object pathie-cpp/CMakeFiles/pathie.dir/src/errors.cpp.o
[ 25%] Building CXX object pathie-cpp/CMakeFiles/pathie.dir/src/entry_iterator.cpp.o
[ 37%] Building CXX object pathie-cpp/CMakeFiles/pathie.dir/src/path.cpp.o
[ 50%] Building CXX object pathie-cpp/CMakeFiles/pathie.dir/src/temp.cpp.o
[ 62%] Building CXX object pathie-cpp/CMakeFiles/pathie.dir/src/pathie.cpp.o
[ 75%] Linking CXX static library libpathie.a
[ 75%] Built target pathie
[ 87%] Building CXX object CMakeFiles/list_app_dirs.dir/src/main.cpp.o
[100%] Linking CXX executable list_app_dirs
[100%] Built target list_app_dirs
```