### PR TITLE
Handle ENOTDIR errno in Path::exists()

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1478,7 +1478,7 @@ bool Path::exists() const
 
   if (access(nstr.c_str(), F_OK) == -1) {
     int errsav = errno;
-    if (errsav == ENOENT) {
+    if (errsav == ENOENT || errsav == ENOTDIR) {
       return false;
     }
     else {
@@ -1491,7 +1491,7 @@ bool Path::exists() const
   std::wstring utf16 = utf8_to_utf16(m_path);
   if (_waccess(utf16.c_str(), F_OK) == -1) {
     int errsav = errno;
-    if (errsav == ENOENT) {
+    if (errsav == ENOENT || errsav == ENOTDIR) {
       return false;
     }
     else {


### PR DESCRIPTION
Previously, Path::exists() would produce an exception when a parent of
the checked path existed, but was not a directory (for example: if
the user called `Path("foo/baz.txt").exists()` when "foo" was a file).

This change makes Pathie act similarly to path libraries such as
Python's pathlib, which returns false given the same inputs.