### PR TITLE
fix potential memory leak.

### DIFF
--- a/src/entry_iterator.cpp
+++ b/src/entry_iterator.cpp
@@ -64,7 +64,16 @@ entry_iterator::entry_iterator(const Path* p_directory)
     mp_cur(NULL),
     mp_cur_path(new Path())
 {
-  open_native_handle();
+	try
+	{
+		open_native_handle();
+	}
+	catch (...)
+	{
+		delete mp_cur_path;
+		mp_cur_path = NULL;
+		throw;
+	}
 }
 
 /**
@@ -267,12 +276,12 @@ entry_iterator& entry_iterator::operator=(const entry_iterator& other)
 {
   mp_directory      = other.mp_directory;
   mp_cur            = other.mp_cur;
-  mp_cur_path       = other.mp_cur_path;
+  *mp_cur_path       = *other.mp_cur_path;
 
   entry_iterator& e = const_cast<entry_iterator&>(other);
   e.mp_directory    = NULL;
   e.mp_cur          = NULL;
-  e.mp_cur_path     = new Path();
+  *e.mp_cur_path     = Path();
 
   return *this;
 }

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -82,10 +82,10 @@ WindowsError::WindowsError(DWORD val)
   ss << val;
 
   wchar_t* buf = NULL;
-  FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+  FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
                  NULL,
                  val,
-                 LANG_USER_DEFAULT,
+				 MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US),
                  (wchar_t*) &buf, // What a weird API.
                  0,
                  NULL);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -95,7 +95,7 @@ Path::localpathtype Path::c_localdefault = LOCALPATH_LOCAL;
  */
 Path::Path()
 {
-  m_path = ".";
+  m_path = "";
 }
 
 /**

--- a/src/pathie.cpp
+++ b/src/pathie.cpp
@@ -47,7 +47,10 @@ std::string Pathie::utf16_to_utf8(std::wstring str)
   size = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), str.length(), utf8, size,  NULL, NULL);
 
   if (size == 0)
-    throw(Pathie::WindowsError(GetLastError()));
+  {
+	  free(utf8);
+	  throw(Pathie::WindowsError(GetLastError()));
+  }
 
   std::string utf8str(utf8, size);
   free(utf8);
@@ -69,7 +72,10 @@ std::wstring Pathie::utf8_to_utf16(std::string str)
   count = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), str.length(), utf16, count);
 
   if (count == 0)
-    throw(Pathie::WindowsError(GetLastError()));
+  {
+	  free(utf16);
+	  throw(Pathie::WindowsError(GetLastError()));
+  }
 
   std::wstring utf16str(utf16, count);
   free(utf16);
@@ -122,8 +128,11 @@ std::string Pathie::convert_encodings(const char* from_encoding, const char* to_
   size_t outbytes_left = 0;
   size_t inbytes_left  = input_length;
 
-  if (converter == (iconv_t) -1)
-    throw Pathie::ErrnoError(errno);
+  if (converter == (iconv_t)-1)
+  {
+	  free(copy);
+	  throw Pathie::ErrnoError(errno);
+  }
 
   /* There is no way to know how much space iconv() will need. So we keep
    * allocating more and more memory as needed. `current_size' keeps track


### PR DESCRIPTION
if given a invalid path, call to Path::children() function may lead to a memory leak due to throw in construct body.

like call Path("\tmp").children() in windows os.